### PR TITLE
Added custom file names to be handled directly from app before export

### DIFF
--- a/lib/to_csv.dart
+++ b/lib/to_csv.dart
@@ -1,18 +1,17 @@
 library to_csv;
 
 import 'dart:convert';
- 
+
 import 'package:file_saver/file_saver.dart';
 import 'package:flutter/foundation.dart';
 import 'package:csv/csv.dart';
 import 'package:intl/intl.dart';
 import 'package:share_plus/share_plus.dart';
 import 'dart:io';
-import 'package:universal_html/html.dart' as html; 
+import 'package:universal_html/html.dart' as html;
 
-
-
-myCSV(List<String> headerRow, List<List<String>> listOfListOfStrings,{bool sharing = false}) async{
+myCSV(List<String> headerRow, List<List<String>> listOfListOfStrings,
+    {bool sharing = false, String? fileName, String? fileTimeStamp}) async {
   debugPrint("***** Gonna Create cv");
 
   //* A list of header
@@ -34,6 +33,9 @@ myCSV(List<String> headerRow, List<List<String>> listOfListOfStrings,{bool shari
   //   //Now that its confirmed that length of header elements and row elemnts are same lets create the csvFile
   // }
 
+  //specify file name
+  String givenFileName = "${fileName ?? 'item_export'}_";
+
   //create the final list of lists containing the header and the data
   List<List<String>> headerAndDataList = [];
   headerAndDataList.add(headerRow);
@@ -44,26 +46,26 @@ myCSV(List<String> headerRow, List<List<String>> listOfListOfStrings,{bool shari
   String csvData = const ListToCsvConverter().convert(headerAndDataList);
 
   DateTime now = DateTime.now();
+
+  //allow user to specify a specific timestamp that was saved with record
   String formattedData =
-  DateFormat('MM-dd-yyyy-HH-mm-ss')
-      .format(now);
+      fileTimeStamp ?? DateFormat('MM-dd-yyyy-HH-mm-ss').format(now);
+
   if (kIsWeb) {
     final bytes = utf8.encode(csvData);
     final blob = html.Blob([bytes]);
-    final url =
-    html.Url.createObjectUrlFromBlob(blob);
-    final anchor = html.document
-        .createElement('a') as html.AnchorElement
+    final url = html.Url.createObjectUrlFromBlob(blob);
+    final anchor = html.document.createElement('a') as html.AnchorElement
       ..href = url
       ..style.display = 'none'
-      ..download =
-          'item_export_$formattedData.csv';
+      ..download = '$givenFileName$formattedData.csv';
     html.document.body!.children.add(anchor);
     anchor.click();
     html.Url.revokeObjectUrl(url);
-  }
-  else if(Platform.isAndroid || Platform.isIOS || Platform.isWindows || Platform.isMacOS) {
-  
+  } else if (Platform.isAndroid ||
+      Platform.isIOS ||
+      Platform.isWindows ||
+      Platform.isMacOS) {
 /*    Directory? director = await getExternalStorageDirectory();
     debugPrint('2');
     final File file = await (File('${director!.path}/item_export_$formattedData.csv').create());
@@ -73,11 +75,15 @@ myCSV(List<String> headerRow, List<List<String>> listOfListOfStrings,{bool shari
     final bytes = utf8.encode(csvData);
     Uint8List bytes2 = Uint8List.fromList(bytes);
     MimeType type = MimeType.csv;
-    String? unknownValue = await FileSaver.instance.saveAs(name:'item_export_$formattedData.csv',bytes: bytes2, ext:'csv',mimeType:type);
+    String? unknownValue = await FileSaver.instance.saveAs(
+        name: '$givenFileName$formattedData.csv',
+        bytes: bytes2,
+        ext: 'csv',
+        mimeType: type);
     print("Unknown value $unknownValue");
-    if(sharing == true){ 
-        XFile xFile = XFile.fromData(bytes2); 
-        await Share.shareXFiles([xFile], text: 'Csv File');
+    if (sharing == true) {
+      XFile xFile = XFile.fromData(bytes2);
+      await Share.shareXFiles([xFile], text: 'Csv File');
     }
   }
 }

--- a/lib/to_csv.dart
+++ b/lib/to_csv.dart
@@ -10,7 +10,7 @@ import 'package:share_plus/share_plus.dart';
 import 'dart:io';
 import 'package:universal_html/html.dart' as html;
 
-myCSV(List<String> headerRow, List<List<String>> listOfListOfStrings,
+Future myCSV(List<String> headerRow, List<List<String>> listOfListOfStrings,
     {bool sharing = false, String? fileName, String? fileTimeStamp}) async {
   debugPrint("***** Gonna Create cv");
 
@@ -36,6 +36,12 @@ myCSV(List<String> headerRow, List<List<String>> listOfListOfStrings,
   //specify file name
   String givenFileName = "${fileName ?? 'item_export'}_";
 
+  DateTime now = DateTime.now();
+
+  //allow user to specify a specific timestamp that was saved with record
+  String formattedDate =
+      fileTimeStamp ?? DateFormat('MM-dd-yyyy-HH-mm-ss').format(now);
+
   //create the final list of lists containing the header and the data
   List<List<String>> headerAndDataList = [];
   headerAndDataList.add(headerRow);
@@ -45,12 +51,6 @@ myCSV(List<String> headerRow, List<List<String>> listOfListOfStrings,
 
   String csvData = const ListToCsvConverter().convert(headerAndDataList);
 
-  DateTime now = DateTime.now();
-
-  //allow user to specify a specific timestamp that was saved with record
-  String formattedData =
-      fileTimeStamp ?? DateFormat('MM-dd-yyyy-HH-mm-ss').format(now);
-
   if (kIsWeb) {
     final bytes = utf8.encode(csvData);
     final blob = html.Blob([bytes]);
@@ -58,7 +58,7 @@ myCSV(List<String> headerRow, List<List<String>> listOfListOfStrings,
     final anchor = html.document.createElement('a') as html.AnchorElement
       ..href = url
       ..style.display = 'none'
-      ..download = '$givenFileName$formattedData.csv';
+      ..download = '$givenFileName$formattedDate.csv';
     html.document.body!.children.add(anchor);
     anchor.click();
     html.Url.revokeObjectUrl(url);
@@ -68,7 +68,7 @@ myCSV(List<String> headerRow, List<List<String>> listOfListOfStrings,
       Platform.isMacOS) {
 /*    Directory? director = await getExternalStorageDirectory();
     debugPrint('2');
-    final File file = await (File('${director!.path}/item_export_$formattedData.csv').create());
+    final File file = await (File('${director!.path}/item_export_$formattedDate.csv').create());
     debugPrint('3');
     await file.writeAsString(csvData).then((value) => debugPrint("File created and downloaded"));*/
 
@@ -76,7 +76,7 @@ myCSV(List<String> headerRow, List<List<String>> listOfListOfStrings,
     Uint8List bytes2 = Uint8List.fromList(bytes);
     MimeType type = MimeType.csv;
     String? unknownValue = await FileSaver.instance.saveAs(
-        name: '$givenFileName$formattedData',
+        name: '$givenFileName$formattedDate',
         bytes: bytes2,
         ext: 'csv',
         mimeType: type);

--- a/lib/to_csv.dart
+++ b/lib/to_csv.dart
@@ -76,7 +76,7 @@ myCSV(List<String> headerRow, List<List<String>> listOfListOfStrings,
     Uint8List bytes2 = Uint8List.fromList(bytes);
     MimeType type = MimeType.csv;
     String? unknownValue = await FileSaver.instance.saveAs(
-        name: '$givenFileName$formattedData.csv',
+        name: '$givenFileName$formattedData',
         bytes: bytes2,
         ext: 'csv',
         mimeType: type);


### PR DESCRIPTION
Fixes #10 

- File name was statically assigned to _"item_export"__ for all exported files until directory specification. What was added gives user the chance to dynamically change name of export file before export directly in the app.

- Files were saved with _".csv.csv"_ duplicate extension because of explicit declaration and implicit extension specification through the _"ext: csv"_ parameter of FileSaver package

- **myCSV()** was made explicitly Future so that functions such as to display a toast after saving can be done with the .then() provision